### PR TITLE
docs: simplify wording

### DIFF
--- a/mission-statement.md
+++ b/mission-statement.md
@@ -1,17 +1,20 @@
 # Mission statement
 
-Technology is great. We firmly believe there is more to building
-software than to making it work one way or the other.
+Technology is great. We believe there is more to building
+software than making it work one way or the other.
 
-There are always elegant patterns to sculpt, bytes to shove off and complexities
-to simplify. We work hard to do exactly that and spread the knowledge about it to everyone.
+There are elegant patterns to sculpt, bytes to shove off and complexities
+to simplify. We work hard to do that and spread the knowledge about it.
 
 Good solutions and new paths do not come without dangers. Things will go wrong –
-we know that and will account for the risks. New paths will be hard and inconvenient –
-we accept these hardships to create the best projects possible, for our colleagues and customers.
+we know that and will account for the risks. New path are inconvenient –
+we accept the hardships to create the best projects, for our colleagues and customers.
 
-We take on the hard fights. Most of the time we go where the big and hard problems are, this includes
-projects with unwieldy legacy code bases, encrusted processes or gigantic scopes.
+We take on the hard fights.
+We tame unwieldy legacy code bases,
+force open encrusted processes and
+deconstruct gigantic scopes.
+We go where the big and daunting problems are.
 
 Because exploring the best solution is so much fun, we fight for it.
 Every day, radically and courageously.


### PR DESCRIPTION
This removes twisted germanisms from the mission statement. 
Also works on #1.