### PR TITLE
fix(spec): correct typos

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -46,10 +46,10 @@ In order to help teams advance in an ordered and sustainable manner, the
 creation of a <a>Free Radical</a> role is proposed.
 
 This document explains the proposed role for everyone interested in
-understanding the work of <a>Free Radical</a>s. Notable audience are potential
+understanding the work of <a>Free Radical</a>s. The notable audiences are potential
 employees and employees striving to take on the role.
 
-List order do not infer any prioritization.
+List order does not infer any prioritization.
 
 Terminology {#m}
 ================
@@ -80,10 +80,10 @@ effects.
 
 *  General technical advancement of the company
 *  General methodological advancement of the company
-*  Mid- and longterm productivity gains
+*  Mid- and long-term productivity gains
 *  Improved reliability and quality of software projects
 *  Distribution of advanced technology knowledge
-*  Discover improvements and and potential of new technologies
+*  Discover improvements and potential of new technologies
 *  Improved attractiveness of company for product engineers
 
 Tasks {#tasks}
@@ -114,7 +114,7 @@ the following abilities:
 *  Ability to draft and implement sound technical concepts
 *  Excellent general problem-solving capabilities
 *  High capacity for learning new concepts and techniques
-*  Ability to communicate and convince others of new techniques, methods and concept
+*  Ability to communicate and convince others of new techniques, methods, and concept
 *  Excellent skills in delivery and implementation
 *  Good abilities in explaining solutions and techniques to others
 *  Ability to reason about technical solutions in a nuanced and pragmatic manner
@@ -126,7 +126,7 @@ and qualities
 *  Readiness to learn far beyond the personal horizon
 *  Capabilities to think outside of traditional and present boundaries
 *  Courage to assume calculated risks
-*  Strong sense for opportunities and risks of applied technology
+*  Strong sense of opportunities and risks of applied technology
 
 Frame conditions {#conditions}
 ==============================

--- a/index.html
+++ b/index.html
@@ -1336,7 +1336,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Free Radical</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-13">13 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-12-02">2 December 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1398,9 +1398,9 @@ benefits versus using known approaches and techniques.</p>
    <p>In order to help teams advance in an ordered and sustainable manner, the
 creation of a <a data-link-type="dfn" href="#free-radical" id="ref-for-free-radical-1">Free Radical</a> role is proposed.</p>
    <p>This document explains the proposed role for everyone interested in
-understanding the work of <a data-link-type="dfn" href="#free-radical" id="ref-for-free-radical-2">Free Radical</a>s. Notable audience are potential
+understanding the work of <a data-link-type="dfn" href="#free-radical" id="ref-for-free-radical-2">Free Radical</a>s. The notable audiences are potential
 employees and employees striving to take on the role.</p>
-   <p>List order do not infer any prioritization.</p>
+   <p>List order does not infer any prioritization.</p>
    <h2 class="heading settled" data-level="2" id="m"><span class="secno">2. </span><span class="content">Terminology</span><a class="self-link" href="#m"></a></h2>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Free Radical" data-noexport="" id="free-radical">Free Radical<span class="dfn-panel" data-deco=""><b><a href="#free-radical">#free-radical</a></b><b>Referenced in:</b><span><a href="#ref-for-free-radical-1">1. Introduction</a> <a href="#ref-for-free-radical-2">(2)</a></span><span><a href="#ref-for-free-radical-3">2. Terminology</a></span><span><a href="#ref-for-free-radical-4">4. Desired Effects</a></span><span><a href="#ref-for-free-radical-5">5. Tasks</a> <a href="#ref-for-free-radical-6">(2)</a></span><span><a href="#ref-for-free-radical-7">6. Requirements</a> <a href="#ref-for-free-radical-8">(2)</a></span><span><a href="#ref-for-free-radical-9">7. Frame conditions</a> <a href="#ref-for-free-radical-10">(2)</a> <a href="#ref-for-free-radical-11">(3)</a> <a href="#ref-for-free-radical-12">(4)</a> <a href="#ref-for-free-radical-13">(5)</a> <a href="#ref-for-free-radical-14">(6)</a></span><span><a href="#ref-for-free-radical-15">8. Supporting Measures</a> <a href="#ref-for-free-radical-16">(2)</a> <a href="#ref-for-free-radical-17">(3)</a> <a href="#ref-for-free-radical-18">(4)</a></span></span></dfn> defines a role employees working in software development
 can take on. Organizations implementing the <a data-link-type="dfn" href="#free-radical" id="ref-for-free-radical-3">Free Radical</a> role can
@@ -1423,13 +1423,13 @@ effects.</p>
     <li data-md="">
      <p>General methodological advancement of the company</p>
     <li data-md="">
-     <p>Mid- and longterm productivity gains</p>
+     <p>Mid- and long-term productivity gains</p>
     <li data-md="">
      <p>Improved reliability and quality of software projects</p>
     <li data-md="">
      <p>Distribution of advanced technology knowledge</p>
     <li data-md="">
-     <p>Discover improvements and and potential of new technologies</p>
+     <p>Discover improvements and potential of new technologies</p>
     <li data-md="">
      <p>Improved attractiveness of company for product engineers</p>
    </ul>
@@ -1471,7 +1471,7 @@ the following abilities:</p>
     <li data-md="">
      <p>High capacity for learning new concepts and techniques</p>
     <li data-md="">
-     <p>Ability to communicate and convince others of new techniques, methods and concept</p>
+     <p>Ability to communicate and convince others of new techniques, methods, and concept</p>
     <li data-md="">
      <p>Excellent skills in delivery and implementation</p>
     <li data-md="">
@@ -1491,7 +1491,7 @@ and qualities</p>
     <li data-md="">
      <p>Courage to assume calculated risks</p>
     <li data-md="">
-     <p>Strong sense for opportunities and risks of applied technology</p>
+     <p>Strong sense of opportunities and risks of applied technology</p>
    </ul>
    <h2 class="heading settled" data-level="7" id="conditions"><span class="secno">7. </span><span class="content">Frame conditions</span><a class="self-link" href="#conditions"></a></h2>
    <p>For efficient implementation of the <a data-link-type="dfn" href="#free-radical" id="ref-for-free-radical-9">Free Radical</a> role the following

--- a/mission-statement.md
+++ b/mission-statement.md
@@ -7,7 +7,7 @@ There are elegant patterns to sculpt, bytes to shove off and complexities
 to simplify. We work hard to do that and spread the knowledge about it.
 
 Good solutions and new paths do not come without dangers. Things will go wrong –
-we know that and will account for the risks. New path are inconvenient –
+we know that and will account for the risks. New paths are inconvenient –
 we accept the hardships to create the best projects, for our colleagues and customers.
 
 We take on the hard fights.

--- a/readme.md
+++ b/readme.md
@@ -1,42 +1,45 @@
 # Free Radical
 
-This specification defines a framework for implementation of the Free Radical Role. It does so by defining desired effects and requirements for employees and their work in order to fulfill the Free Radical Role.
+This specification defines a framework for implementation of the Free Radical
+Role. It does so by defining desired effects and requirements for employees and
+their work in order to fulfill the Free Radical Role.
 
 ## Introduction
 
 Technical projects increasingly face contradictions in decision-making,
 methodology and choice of technology.
 
-This development takes place in an environment where technical advancement
-is considerably accelerating, which makes decision making harder and harder:
-Adopting new methodology and technology for their
-benefits versus using known approaches and techniques.
+This development takes place in an environment where technical advancement is
+considerably accelerating, which makes decision making harder and harder:
+Adopting new methodology and technology for their benefits versus using known
+approaches and techniques.
 
 In order to help teams advance in an ordered and sustainable manner, the
 creation of a <a>Free Radical</a> role is proposed.
 
 This document explains the proposed role for everyone interested in
-understanding the work of <a>Free Radical</a>s. Notable audience are potential
-employees and employees striving to take on the role.
+understanding the work of <a>Free Radical</a>s. The notable audiences are
+potential employees and employees striving to take on the role.
 
 List order does not infer any prioritization.
 
 ## Terminology
 
 <dfn>Free Radical</dfn> defines a role employees working in software development
-can take on. Organizations implementing the <a>Free Radical</a> role can
-assume certain <a href="#effects">desirable effects</a> taking hold.
-The role comes with a distinct set of liberties and requirements.
-The <a href="#conditions">Frame conditions</a> to set for efficient
-implementations and the <a href="#requirements">Requirements</a> an employee
-taking on the role has to fulfill are described in separate sections of this document.
+can take on. Organizations implementing the <a>Free Radical</a> role can assume
+certain <a href="#effects">desirable effects</a> taking hold. The role comes
+with a distinct set of liberties and requirements. The
+<a href="#conditions">Frame conditions</a> to set for efficient implementations
+and the <a href="#requirements">Requirements</a> an employee taking on the role
+has to fulfill are described in separate sections of this document.
 
 ## Scope
 
 The scope of this specification is limited to the definition of the very minimum
 of a framework for the role of a Free Radical.
 
-This specification describes the Free Radical role for employees working in product engineering.
+This specification describes the Free Radical role for employees working in
+product engineering.
 
 ## Desired Effects
 
@@ -45,80 +48,88 @@ This specification describes the Free Radical role for employees working in prod
 The <a>Free Radical</a> role is defined as to achieve the following desirable
 effects.
 
--   General technical advancement of the company
--   General methodological advancement of the company
--   Mid- and longterm productivity gains
--   Improved reliability and quality of software projects
--   Distribution of advanced technology knowledge
--   Discover improvements and and potential of new technologies
--   Improved attractiveness of company for product engineers
+* General technical advancement of the company
+* General methodological advancement of the company
+* Mid- and long-term productivity gains
+* Improved reliability and quality of software projects
+* Distribution of advanced technology knowledge
+* Discover improvements and potential of new technologies
+* Improved attractiveness of company for product engineers
 
 ## Tasks
 
-<a>Free Radical</a>s <strong>MUST</strong> take on the following tasks in their day-to-day work.
+<a>Free Radical</a>s <strong>MUST</strong> take on the following tasks in their
+day-to-day work.
 
--   General consulting on technical matters
--   Sparring on technical implementations and decisions for all employees.
--   General development work, aiming at establishing Best Practices by example
--   Introduction of new technology and methods
--   Knowledge Transfer
--   Active research of upcoming technology and methods
+* General consulting on technical matters
+* Sparring on technical implementations and decisions for all employees.
+* General development work, aiming at establishing Best Practices by example
+* Introduction of new technology and methods
+* Knowledge Transfer
+* Active research of upcoming technology and methods
 
-<a>Free Radical</a>s <strong>SHOULD</strong> take on the following tasks as they see fit:
+<a>Free Radical</a>s <strong>SHOULD</strong> take on the following tasks as they
+see fit:
 
--   Support and implementation of Open Source Software
--   Presentations and talks inside and outside of the company
+* Support and implementation of Open Source Software
+* Presentations and talks inside and outside of the company
 
 ## Requirements
 
-Employees striving to fulfill the <a>Free Radical</a> role <b>MUST</b> have
-the following abilities:
+Employees striving to fulfill the <a>Free Radical</a> role <b>MUST</b> have the
+following abilities:
 
--   Broad technical knowledge on senior level
--   Ability to draft and implement sound technical concepts
--   Excellent general problem-solving capabilities
--   High capacity for learning new concepts and techniques
--   Ability to communicate and convince others of new techniques, methods and concept
--   Excellent skills in delivery and implementation
--   Ability to reason about technical solutions in a nuanced and pragmatic manner
+* Broad technical knowledge on senior level
+* Ability to draft and implement sound technical concepts
+* Excellent general problem-solving capabilities
+* High capacity for learning new concepts and techniques
+* Ability to communicate and convince others of new techniques, methods, and
+	concept
+* Excellent skills in delivery and implementation
+* Ability to reason about technical solutions in a nuanced and pragmatic manner
 
 Additionally <a>Free Radical</a>s <b>SHOULD</b> sport the following attributes
 and qualities
 
--   Strong motivation to improve upon existing solutions
--   Readiness to learn far beyond the personal horizon
--   Capabilities to think outside of traditional and present boundaries
--   Courage to assume calculated risks
--   Strong sense for opportunities and risks of applied technology
+* Strong motivation to improve upon existing solutions
+* Readiness to learn far beyond the personal horizon
+* Capabilities to think outside of traditional and present boundaries
+* Courage to assume calculated risks
+* Strong sense of opportunities and risks of applied technology
 
 ## Frame conditions
 
-For efficient implementation of the <a>Free Radical</a> role the following
-frame conditions <strong>SHOULD</strong> be met:
+For efficient implementation of the <a>Free Radical</a> role the following frame
+conditions <strong>SHOULD</strong> be met:
 
--   <a>Free Radical</a>s decide independently on their involvement in projects
--   Projects avoid planning with <a>Free Radical</a>s as permanent project members
--   <a>Free Radical</a>s account only partially for their work times
--   <a>Free Radical</a>s have the liberties to take calculated risks in their field of work
--   <a>Free Radical</a>s are directly available for questions and sparring to other employees
+* <a>Free Radical</a>s decide independently on their involvement in projects
+* Projects avoid planning with <a>Free Radical</a>s as permanent project members
+* <a>Free Radical</a>s account only partially for their work times
+* <a>Free Radical</a>s have the liberties to take calculated risks in their
+	field of work
+* <a>Free Radical</a>s are directly available for questions and sparring to
+	other employees
 
 ## Supporting Measures
 
 To help an efficient and successful implementation of the <a>Free Radical</a>
 role a range of additional measures can be taken.
 
--   Regular surveys inquiring about the perceived performance of <a>Free Radicals</a>
--   Transparency about the current work of <a>Free Radicals</a>, e.g. by publishing it on blogs
--   Regular updates on the self-improvement efforts undertaken by <a>Free Radicals</a>
+* Regular surveys inquiring about the perceived performance of <a>Free
+	Radicals</a>
+* Transparency about the current work of <a>Free Radicals</a>, e.g. by
+	publishing it on blogs
+* Regular updates on the self-improvement efforts undertaken by <a>Free
+	Radicals</a>
 
 ## Acknowledgements
 
 The following people have greatly contributed to this specification:
 
--   Clemens Akens
--   Peter Ehrenberg
--   Helge
--   Felicitas Kugland
--   Mario Nebl
--   Janno Rothfos
--   Markus Wolf
+* Clemens Akens
+* Peter Ehrenberg
+* Helge
+* Felicitas Kugland
+* Mario Nebl
+* Janno Rothfos
+* Markus Wolf


### PR DESCRIPTION
This PR only fixes some typos and grammar errors.

Also, the formatting of the README file has been changed accidentally by [prettier](https://github.com/prettier/prettier) - due to auto format setting. Since nothing on the [contribution guide](https://github.com/sinnerschrader/free-radical-specification/blob/master/contributing.md) prohibits this, I left it as is. I can happily undo it if you want to keep the old style, though :)